### PR TITLE
Invitations are deleted when the network is deleted #7

### DIFF
--- a/src/main/java/net/cryptic_game/microservice/network/model/Network.java
+++ b/src/main/java/net/cryptic_game/microservice/network/model/Network.java
@@ -139,4 +139,12 @@ public class Network extends Model {
 		return name.length() >= 5 && name.length() <= 20 && !name.contains(" ");
 	}
 
+	@Override
+	public void delete() {
+		super.delete();
+		List<Invitation> invitations = Invitation.getInvitationsOfNetwork(uuid, true);
+		invitations.addAll(Invitation.getInvitationsOfNetwork(uuid, false));
+
+		invitations.forEach(Model::delete);
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Invitations to a network will be deleted on its deletion.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#7 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
