### PR TITLE
Add member check when inviting new devices to network

### DIFF
--- a/src/main/java/net/cryptic_game/microservice/network/endpoint/NetworkMemberEndpoint.java
+++ b/src/main/java/net/cryptic_game/microservice/network/endpoint/NetworkMemberEndpoint.java
@@ -42,6 +42,18 @@ public class NetworkMemberEndpoint {
         }
 
         if (Device.checkPermissions(device, user)) {
+
+            if(network.getOwner().equals(device)) {
+                return error("already_member_of_network");
+            }
+
+            List<Member> members = Member.getMembers(uuid);
+            for(Member member : members) {
+                if (member.getDevice().equals(device)) {
+                    return error("already_member_of_network");
+                }
+            }
+
             Invitation invitation = Invitation.request(device, network.getUUID());
 
             return invitation.serialize();

--- a/src/main/java/net/cryptic_game/microservice/network/endpoint/NetworkOwnerEndpoint.java
+++ b/src/main/java/net/cryptic_game/microservice/network/endpoint/NetworkOwnerEndpoint.java
@@ -42,6 +42,17 @@ public class NetworkOwnerEndpoint {
             return JSONUtils.error("network_not_found");
         }
 
+        if(network.getOwner().equals(device)) {
+            return error("already_member_of_network");
+        }
+
+        List<Member> members = Member.getMembers(uuid);
+        for(Member member : members) {
+            if(member.getDevice().equals(device)) {
+                return error("already_member_of_network");
+            }
+        }
+
         Invitation invitation = Invitation.invite(device, network.getUUID());
 
         return invitation.serialize();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a check whether a device is already a member when inviting new devices.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->#6

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
