### PR TITLE
Add [invitations, network] endpoint

### DIFF
--- a/src/main/java/net/cryptic_game/microservice/network/endpoint/NetworkOwnerEndpoint.java
+++ b/src/main/java/net/cryptic_game/microservice/network/endpoint/NetworkOwnerEndpoint.java
@@ -133,6 +133,25 @@ public class NetworkOwnerEndpoint {
         return simple("requests", invitations);
     }
 
+    @UserEndpoint(path = {"invitations", "network"}, keys = {"uuid"}, types = {String.class})
+    public static JSONObject invitationsNetwork(JSON data, UUID user) {
+        UUID uuid = data.getUUID("uuid");
+
+        Network network = Network.get(uuid);
+
+        if (network == null || !Device.checkPermissions(network.getOwner(), user)) {
+            return error("no_permissions");
+        }
+
+        List<JSONObject> invitations = new ArrayList<>();
+
+        for (Invitation invitation : Invitation.getInvitationsOfNetwork(uuid, false)) {
+            invitations.add(invitation.serialize());
+        }
+
+        return simple("invitations", invitations);
+    }
+
     @UserEndpoint(path = {"kick"}, keys = {"uuid", "device"}, types = {String.class, String.class})
     public static JSONObject kick(JSON data, UUID user) {
         UUID uuid = data.getUUID("uuid");

--- a/src/test/java/net/cryptic_game/microservice/network/AppTest.java
+++ b/src/test/java/net/cryptic_game/microservice/network/AppTest.java
@@ -33,6 +33,7 @@ public class AppTest {
                 new ArrayList<>(Collections.singletonList("accept")),
                 new ArrayList<>(Collections.singletonList("deny")),
                 new ArrayList<>(Collections.singletonList("requests")),
+                new ArrayList<>(Arrays.asList("invitations", "network")),
                 new ArrayList<>(Collections.singletonList("kick")),
                 new ArrayList<>(Collections.singletonList("delete")),
                 new ArrayList<>(Collections.singletonList("revoke"))

--- a/src/test/java/net/cryptic_game/microservice/network/endpoint/NetworkOwnerEndpointTest.java
+++ b/src/test/java/net/cryptic_game/microservice/network/endpoint/NetworkOwnerEndpointTest.java
@@ -273,6 +273,31 @@ public class NetworkOwnerEndpointTest {
     }
 
     @Test
+    public void invitationsTest() {
+        networks = new ArrayList<>();
+        invitations = new ArrayList<>();
+
+        UUID network = UUID.randomUUID();
+
+        JSON data = new JSON(JSONBuilder.anJSON().add("uuid", network.toString()).build());
+
+        assertEquals(JSONBuilder.anJSON().add("error", "no_permissions").build(), NetworkOwnerEndpoint.invitationsNetwork(data, UUID.randomUUID()));
+
+        networks.add(new Network(network, UUID.randomUUID(), UUID.randomUUID(), rand.nextBoolean(), "network_" + rand.nextInt(100)));
+        PowerMockito.when(Device.checkPermissions(Mockito.any(), Mockito.any())).thenReturn(false);
+
+        assertEquals(JSONBuilder.anJSON().add("error", "no_permissions").build(), NetworkOwnerEndpoint.invitationsNetwork(data, UUID.randomUUID()));
+
+        invitations.add(new Invitation(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), network, false));
+        PowerMockito.when(Device.checkPermissions(Mockito.any(), Mockito.any())).thenReturn(true);
+
+        List<JSONObject> json = (List<JSONObject>) NetworkOwnerEndpoint.invitationsNetwork(data, UUID.randomUUID()).get("invitations");
+
+        assertEquals(1, json.size());
+        assertEquals(invitations.get(0).serialize(), json.get(0));
+    }
+
+    @Test
     public void kickTest() throws Exception {
         networks = new ArrayList<>();
         invitations = new ArrayList<>();
@@ -353,7 +378,7 @@ public class NetworkOwnerEndpointTest {
 
         assertEquals(JSONBuilder.anJSON().add("error", "invitation_not_found").build(), NetworkOwnerEndpoint.revoke(data, UUID.randomUUID()));
 
-        PowerMockito.when(Device.checkPermissions(Mockito.any(), Mockito.any())).thenReturn(false);;
+        PowerMockito.when(Device.checkPermissions(Mockito.any(), Mockito.any())).thenReturn(false);
         invitations.add(this.invitation);
         networks.add(new Network(network, UUID.randomUUID(), UUID.randomUUID(), rand.nextBoolean(), "network_" + rand.nextInt(100)));
         PowerMockito.when(this.invitation.getNetwork()).thenReturn(network);


### PR DESCRIPTION
## Description
Added a new Endpoint `[invitations, network]` that returns all pending invitations to a network.

## Related Issue
#37 

## How Has This Been Tested?
Unit Tests and local tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
